### PR TITLE
bugfix: remove renamed model from index

### DIFF
--- a/analysis/watcher.go
+++ b/analysis/watcher.go
@@ -40,6 +40,9 @@ func (s *State) WatchProject() {
 			}
 			if event.Op&fsnotify.Rename == fsnotify.Rename && filepath.Ext(event.Name) == s.DbtModelExtension {
 				s.Logger.Debugf("Renaming Event %s", event.Name)
+				if filepath.Ext(event.Name) == s.DbtModelExtension {
+					s.RemoveModelFromIndex(event.Name)
+				}
 			}
 
 		case err := <-s.Watcher.Errors:


### PR DESCRIPTION
when a renaming event is detected by the file watcher, remove the model from index. this effectively makes the behavior of a rename the same as remove+create events