### PR TITLE
refactor: centralize show message notifications

### DIFF
--- a/analysis/notifier.go
+++ b/analysis/notifier.go
@@ -37,10 +37,12 @@ func (s *State) notifySourceState(errs []string) {
 	for _, e := range errs {
 		msg.WriteString("  • " + e + "\n")
 	}
-	s.NotifCh <- lsp.ShowMessageNotification{
-		Notification: lsp.Notification{Method: "window/showMessage"},
-		Params:       lsp.ShowMessageParams{Type: lsp.MessageTypeWarning, Message: msg.String()},
-	}
+	s.ShowMessage(lsp.MessageTypeWarning, msg.String())
+}
+
+// ShowMessage queues a window/showMessage notification for the client.
+func (s *State) ShowMessage(messageType int, message string) {
+	s.NotifCh <- lsp.ShowMessageParams{Type: messageType, Message: message}
 }
 
 // DrainNotifications reads from NotifCh and writes window/showMessage
@@ -56,15 +58,15 @@ func (s *State) DrainNotifications(ctx context.Context) {
 			if !ok {
 				return
 			}
-			s.sendShowMessage(notif.Params.Type, notif.Params.Message)
+			s.sendShowMessage(notif)
 		}
 	}
 }
 
-func (s *State) sendShowMessage(messageType int, message string) {
+func (s *State) sendShowMessage(params lsp.ShowMessageParams) {
 	notif := lsp.ShowMessageNotification{
-		Notification: lsp.Notification{Method: "window/showMessage"},
-		Params:       lsp.ShowMessageParams{Type: messageType, Message: message},
+		Notification: lsp.Notification{Method: lsp.MethodShowMessage},
+		Params:       params,
 	}
 	msgIn, err := rpc.EncodeMsg(notif)
 	if err != nil {
@@ -72,6 +74,9 @@ func (s *State) sendShowMessage(messageType int, message string) {
 		return
 	}
 
-	s.Writer.Write([]byte(msgIn))
+	if _, err := s.Writer.Write([]byte(msgIn)); err != nil {
+		s.Logger.Errorf("Couldn't write ShowMessageNotification: %s", err)
+		return
+	}
 	s.Logger.Infof("Sent ShowMessageNotification of type %d", notif.Params.Type)
 }

--- a/analysis/notifier_test.go
+++ b/analysis/notifier_test.go
@@ -1,0 +1,76 @@
+package analysis
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"dbt_ls/lsp"
+	"dbt_ls/rpc"
+)
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+type signalWriter struct {
+	bytes.Buffer
+	written chan struct{}
+}
+
+func (w *signalWriter) Write(data []byte) (int, error) {
+	n, err := w.Buffer.Write(data)
+	close(w.written)
+	return n, err
+}
+
+func TestShowMessageQueuesParams(t *testing.T) {
+	s := newTestState()
+	s.ShowMessage(lsp.MessageTypeWarning, "warning")
+
+	got := <-s.NotifCh
+	if got != (lsp.ShowMessageParams{Type: lsp.MessageTypeWarning, Message: "warning"}) {
+		t.Fatalf("unexpected queued params: %#v", got)
+	}
+}
+
+func TestDrainNotificationsWritesShowMessage(t *testing.T) {
+	output := &signalWriter{written: make(chan struct{})}
+	s := newTestState()
+	s.Writer = output
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.DrainNotifications(ctx)
+		close(done)
+	}()
+	s.ShowMessage(lsp.MessageTypeInfo, "hello")
+
+	<-output.written
+	cancel()
+	<-done
+
+	method, content, err := rpc.DecodeMsg(output.Bytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if method != lsp.MethodShowMessage {
+		t.Fatalf("method = %q, want %q", method, lsp.MethodShowMessage)
+	}
+	if !bytes.Contains(content, []byte(`"type":3`)) || !bytes.Contains(content, []byte(`"message":"hello"`)) {
+		t.Fatalf("unexpected notification content: %s", content)
+	}
+}
+
+func TestSendShowMessageHandlesWriteError(t *testing.T) {
+	s := newTestState()
+	s.Writer = failingWriter{}
+	s.sendShowMessage(lsp.ShowMessageParams{Type: lsp.MessageTypeError, Message: "failure"})
+}
+
+var _ io.Writer = failingWriter{}

--- a/analysis/sources.go
+++ b/analysis/sources.go
@@ -44,10 +44,7 @@ func (s *State) resetProjectState() {
 }
 
 func (s *State) NotifyProject(message string) {
-	s.NotifCh <- lsp.ShowMessageNotification{
-		Notification: lsp.Notification{Method: "window/showMessage"},
-		Params:       lsp.ShowMessageParams{Type: lsp.MessageTypeError, Message: message},
-	}
+	s.ShowMessage(lsp.MessageTypeError, message)
 }
 
 func (s *State) SetDbtSources(sources DbtSources, file string) {

--- a/analysis/sources_test.go
+++ b/analysis/sources_test.go
@@ -85,7 +85,7 @@ func TestReconcileProjectDeactivatesAndReactivates(t *testing.T) {
 	s.reconcileProject(root)
 	select {
 	case notif := <-s.NotifCh:
-		t.Fatalf("active project reconciliation sent notification: %q", notif.Params.Message)
+		t.Fatalf("active project reconciliation sent notification: %q", notif.Message)
 	default:
 	}
 
@@ -122,15 +122,15 @@ func TestRepeatedProjectIndexingFailureNotifiesOnce(t *testing.T) {
 
 	select {
 	case notif := <-s.NotifCh:
-		if notif.Params.Message != "dbt-ls: project could not be indexed: lstat "+filepath.Join(root, "missing")+": no such file or directory" {
-			t.Fatalf("unexpected notification: %q", notif.Params.Message)
+		if notif.Message != "dbt-ls: project could not be indexed: lstat "+filepath.Join(root, "missing")+": no such file or directory" {
+			t.Fatalf("unexpected notification: %q", notif.Message)
 		}
 	default:
 		t.Fatal("expected indexing failure notification")
 	}
 	select {
 	case notif := <-s.NotifCh:
-		t.Fatalf("repeated indexing failure sent notification: %q", notif.Params.Message)
+		t.Fatalf("repeated indexing failure sent notification: %q", notif.Message)
 	default:
 	}
 }

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -33,7 +33,7 @@ type State struct {
 	DbtRoots            []string
 	SourcesValid        bool
 	SourceFileErrors    map[string][]sourceFileError // keyed by file path; guarded by DbtConfigMu
-	NotifCh             chan lsp.ShowMessageNotification
+	NotifCh             chan lsp.ShowMessageParams
 	configFileHashes    map[string]string // file path → sha256 of last-processed content
 	configFileHashesMu  sync.Mutex
 	DbtSourcesByFile    map[string]DbtSources
@@ -112,7 +112,7 @@ func NewState(
 		Documents:           map[string]*Document{},
 		SourcesValid:        true,
 		SourceFileErrors:    map[string][]sourceFileError{},
-		NotifCh:             make(chan lsp.ShowMessageNotification, 16),
+		NotifCh:             make(chan lsp.ShowMessageParams, 16),
 		configFileHashes:    map[string]string{},
 		DbtSourcesByFile:    map[string]DbtSources{},
 		SourceTableIndex:    map[sourceTableKey]map[string]sourceDecl{},

--- a/lsp/window.go
+++ b/lsp/window.go
@@ -5,6 +5,7 @@ const (
 	MessageTypeWarning = 2
 	MessageTypeInfo    = 3
 	MessageTypeLog     = 4
+	MethodShowMessage  = "window/showMessage"
 )
 
 type ShowMessageParams struct {


### PR DESCRIPTION
## Summary
- Centralize `State.ShowMessage` enqueueing; the channel now carries `ShowMessageParams`.
- Centralize the method constant and add write error handling.
- Add tests.

## Validation
- `go test ./...`
- `go test -race ./...`

Outbound writer serialization is out of scope.