### PR TITLE
Implement per-capability state, code gates

### DIFF
--- a/analysis/completion.go
+++ b/analysis/completion.go
@@ -14,7 +14,11 @@ type SourceCompletionContext struct {
 	TablePrefix string
 }
 
-func (s *State) createRefResponse(lineContent string, params lsp.CompletionParams, response *lsp.CompletionResponse) {
+func (s *State) createRefResponse(
+	lineContent string,
+	params lsp.CompletionParams,
+	response *lsp.CompletionResponse,
+) {
 	modelRef, check := extractModelRefUnderCursor(lineContent, params.Position)
 	s.Logger.Tracef("Check: %t. Search: %s. Models: %+v", check, modelRef, s.DbtModels)
 
@@ -43,13 +47,20 @@ func (s *State) createRefResponse(lineContent string, params lsp.CompletionParam
 				},
 			})
 		}
-		s.Logger.Tracef("TextDocumentCodeCompletion (Ref) ready. Contains %d items", len(response.Result.Items))
+		s.Logger.Tracef(
+			"TextDocumentCodeCompletion (Ref) ready. Contains %d items",
+			len(response.Result.Items),
+		)
 	} else {
 		s.Logger.Tracef("Cannot parse line contents for Ref completion: %s", lineContent)
 	}
 }
 
-func (s *State) createSourceResponse(lineContent string, params lsp.CompletionParams, response *lsp.CompletionResponse) {
+func (s *State) createSourceResponse(
+	lineContent string,
+	params lsp.CompletionParams,
+	response *lsp.CompletionResponse,
+) {
 	ctx, check := extractSourceContextUnderCursor(lineContent, params.Position)
 	s.Logger.Tracef("Source context: %+v, check: %t", ctx, check)
 	if !check {
@@ -59,11 +70,6 @@ func (s *State) createSourceResponse(lineContent string, params lsp.CompletionPa
 
 	s.DbtConfigMu.Lock()
 	defer s.DbtConfigMu.Unlock()
-
-	if !s.SourcesValid {
-		s.Logger.Debugf("Source config is invalid; skipping source completion")
-		return
-	}
 
 	switch ctx.Kind {
 	case "source_name":
@@ -111,7 +117,10 @@ func (s *State) createSourceResponse(lineContent string, params lsp.CompletionPa
 		}
 	}
 
-	s.Logger.Tracef("TextDocumentCodeCompletion (Source) ready. Contains %d items", len(response.Result.Items))
+	s.Logger.Tracef(
+		"TextDocumentCodeCompletion (Source) ready. Contains %d items",
+		len(response.Result.Items),
+	)
 }
 
 func sourceNamesWithPrefix(cfg DbtConfig, prefix string) []string {
@@ -155,7 +164,10 @@ func NewCompletionResponse(id int) *lsp.CompletionResponse {
 	}
 }
 
-func (s *State) TextDocumentCodeCompletion(id int, params lsp.CompletionParams) lsp.CompletionResponse {
+func (s *State) TextDocumentCodeCompletion(
+	id int,
+	params lsp.CompletionParams,
+) lsp.CompletionResponse {
 	response := NewCompletionResponse(id)
 	if !s.IsServerActive() {
 		return *response
@@ -173,8 +185,15 @@ func (s *State) TextDocumentCodeCompletion(id int, params lsp.CompletionParams) 
 		s.Logger.Tracef("Completion Type: %s", completionType)
 		switch completionType {
 		case "ref":
+			if !s.IsRefCompletionEnabled() {
+				return *response
+			}
 			s.createRefResponse(line, params, response)
 		case "source":
+			if !s.IsSourceCompletionEnabled() {
+				s.Logger.Debugf("Source completion disabled; skipping source completion")
+				return *response
+			}
 			s.createSourceResponse(line, params, response)
 		}
 	}
@@ -201,7 +220,10 @@ func parseCompletionType(lineContent string) (string, error) {
 	)
 }
 
-func extractModelRefUnderCursor(lineContent string, position lsp.TextDocumentPosition) (string, bool) {
+func extractModelRefUnderCursor(
+	lineContent string,
+	position lsp.TextDocumentPosition,
+) (string, bool) {
 	// Group 1: Matches content inside single quotes
 	// Group 2: Matches content inside double quotes
 	re := regexp.MustCompile(`ref\s*\(\s*(?:'([^']+)'|"([^"]+)")\s*\)`)
@@ -235,10 +257,15 @@ func extractModelRefUnderCursor(lineContent string, position lsp.TextDocumentPos
 // extractSourceContextUnderCursor returns the completion context for a
 // source(...) call, determining whether the cursor is positioned on the
 // source-name argument or the table-name argument.
-func extractSourceContextUnderCursor(lineContent string, position lsp.TextDocumentPosition) (SourceCompletionContext, bool) {
+func extractSourceContextUnderCursor(
+	lineContent string,
+	position lsp.TextDocumentPosition,
+) (SourceCompletionContext, bool) {
 	// Matches: source( <arg1> , <arg2> )
 	// We look for the cursor being inside arg1 (source name) or arg2 (table name).
-	re := regexp.MustCompile(`source\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*(?:,\s*(?:'([^']*)'|"([^"]*)")\s*)?\)`)
+	re := regexp.MustCompile(
+		`source\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*(?:,\s*(?:'([^']*)'|"([^"]*)")\s*)?\)`,
+	)
 	matches := re.FindAllStringSubmatchIndex(lineContent, -1)
 
 	for _, match := range matches {
@@ -292,7 +319,9 @@ func extractSourceContextUnderCursor(lineContent string, position lsp.TextDocume
 	}
 
 	// Fallback: table name partial (source name closed, comma seen, table not closed)
-	rePartialTable := regexp.MustCompile(`source\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*,\s*['"]([^'"]*)$`)
+	rePartialTable := regexp.MustCompile(
+		`source\s*\(\s*(?:'([^']*)'|"([^"]*)")\s*,\s*['"]([^'"]*)$`,
+	)
 	partialTableMatch := rePartialTable.FindStringSubmatchIndex(lineContent[:position.Character])
 	if partialTableMatch != nil {
 		srcName := ""

--- a/analysis/definition.go
+++ b/analysis/definition.go
@@ -17,7 +17,7 @@ func (s *State) TextDocumentGoToDefinition(
 			ID:  &id,
 		},
 	}
-	if !s.IsServerActive() {
+	if !s.IsDefinitionEnabled() {
 		return response
 	}
 

--- a/analysis/project.go
+++ b/analysis/project.go
@@ -73,6 +73,7 @@ func (s *State) isProjectConfigFile(path string) bool {
 func (s *State) deactivateProject(root, message string) {
 	wasActive := s.IsServerActive()
 	s.setServerActive(false)
+	s.disableProjectCapabilities()
 	s.resetProjectState()
 	s.ProjectMu.Lock()
 	s.ProjectConfigPath = ""
@@ -93,6 +94,7 @@ func (s *State) activateProject(root, configPath string, project DbtProject) err
 		s.deactivateProject(root, fmt.Sprintf("dbt-ls: project could not be indexed: %s", err))
 		return err
 	}
+	s.enableProjectCapabilities(s.sourcesEnabled())
 	s.setServerActive(true)
 	return nil
 }

--- a/analysis/sources.go
+++ b/analysis/sources.go
@@ -18,16 +18,16 @@ func (s *State) SetDbtProject(project DbtProject, file string) {
 	s.DbtConfig.Name = project.Name
 	s.updateDbtSourcesForFileLocked(project.DbtSources, file)
 	errs := s.allSourceErrorsLocked()
-	s.SourcesValid = len(errs) == 0
 	s.DbtConfigMu.Unlock()
+	s.setSourcesEnabled(len(errs) == 0)
 
 	s.notifySourceState(errs)
 }
 
 func (s *State) resetProjectState() {
+	s.disableProjectCapabilities()
 	s.DbtConfigMu.Lock()
 	s.DbtConfig = DbtConfig{}
-	s.SourcesValid = true
 	s.SourceFileErrors = map[string][]sourceFileError{}
 	s.DbtSourcesByFile = map[string]DbtSources{}
 	s.SourceTableIndex = map[sourceTableKey]map[string][]sourceDecl{}
@@ -51,8 +51,8 @@ func (s *State) SetDbtSources(sources DbtSources, file string) {
 	s.DbtConfigMu.Lock()
 	s.updateDbtSourcesForFileLocked(sources, file)
 	errs := s.allSourceErrorsLocked()
-	s.SourcesValid = len(errs) == 0
 	s.DbtConfigMu.Unlock()
+	s.setSourcesEnabled(len(errs) == 0)
 
 	s.notifySourceState(errs)
 }
@@ -290,7 +290,7 @@ func (s *State) RemoveConfigYaml(file string) {
 	delete(s.SourceFileErrors, file)
 	s.recomputeAffectedSourceTablesLocked(affectedKeys)
 	errs := s.allSourceErrorsLocked()
-	s.SourcesValid = len(errs) == 0
 	s.DbtConfigMu.Unlock()
+	s.setSourcesEnabled(len(errs) == 0)
 	s.notifySourceState(errs)
 }

--- a/analysis/sources_test.go
+++ b/analysis/sources_test.go
@@ -37,8 +37,12 @@ func TestRemoveConfigYamlRemovesSourcesAndHash(t *testing.T) {
 	if _, ok := s.configFileHashes[file]; ok {
 		t.Fatal("hash for removed file remains")
 	}
-	if len(s.DbtConfig.Sources) != 0 || !s.SourcesValid {
-		t.Fatalf("computed source state not cleared: %#v, valid=%t", s.DbtConfig.Sources, s.SourcesValid)
+	if len(s.DbtConfig.Sources) != 0 || !s.ServerCapabilitiesStatus.SourcesEnabled {
+		t.Fatalf(
+			"computed source state not cleared: %#v, valid=%t",
+			s.DbtConfig.Sources,
+			s.ServerCapabilitiesStatus.SourcesEnabled,
+		)
 	}
 }
 
@@ -48,14 +52,18 @@ func TestRemoveConfigYamlResolvesCollision(t *testing.T) {
 	b := filepath.Join(t.TempDir(), "b.yml")
 	s.SetDbtSources(testSource("warehouse", "orders"), a)
 	s.SetDbtSources(testSource("warehouse", "orders"), b)
-	if s.SourcesValid {
+	if s.ServerCapabilitiesStatus.SourcesEnabled {
 		t.Fatal("expected duplicate source table to be invalid")
 	}
 
 	s.RemoveConfigYaml(b)
 
-	if !s.SourcesValid || len(s.SourceFileErrors) != 0 {
-		t.Fatalf("collision was not resolved: valid=%t errors=%#v", s.SourcesValid, s.SourceFileErrors)
+	if !s.ServerCapabilitiesStatus.SourcesEnabled || len(s.SourceFileErrors) != 0 {
+		t.Fatalf(
+			"collision was not resolved: valid=%t errors=%#v",
+			s.ServerCapabilitiesStatus.SourcesEnabled,
+			s.SourceFileErrors,
+		)
 	}
 	if got := s.DbtConfig.Sources["warehouse"].Tables["orders"].SourceFile; got != a {
 		t.Fatalf("remaining table source file = %q, want %q", got, a)
@@ -75,10 +83,12 @@ func TestDuplicateSourceTableInSameFileIsInvalid(t *testing.T) {
 
 	s.SetDbtSources(sources, file)
 
-	if s.SourcesValid {
+	if s.ServerCapabilitiesStatus.SourcesEnabled {
 		t.Fatal("expected duplicate source table to be invalid")
 	}
-	if got := len(s.SourceTableIndex[sourceTableKey{Source: "warehouse", Table: "orders"}][file]); got != 2 {
+	if got := len(
+		s.SourceTableIndex[sourceTableKey{Source: "warehouse", Table: "orders"}][file],
+	); got != 2 {
 		t.Fatalf("indexed declarations = %d, want 2", got)
 	}
 	if got := len(s.SourceFileErrors[file]); got != 1 {
@@ -104,15 +114,19 @@ func TestUpdatingSameFileResolvesDuplicateSourceTable(t *testing.T) {
 	s.SetDbtSources(duplicate, file)
 	s.SetDbtSources(testSource("warehouse", "orders"), file)
 
-	if !s.SourcesValid || len(s.SourceFileErrors) != 0 {
-		t.Fatalf("duplicate was not resolved: valid=%t errors=%#v", s.SourcesValid, s.SourceFileErrors)
+	if !s.ServerCapabilitiesStatus.SourcesEnabled || len(s.SourceFileErrors) != 0 {
+		t.Fatalf(
+			"duplicate was not resolved: valid=%t errors=%#v",
+			s.ServerCapabilitiesStatus.SourcesEnabled,
+			s.SourceFileErrors,
+		)
 	}
 }
 
 func TestRemoveConfigYamlUnknownFileIsNoOp(t *testing.T) {
 	s := newTestState()
 	s.RemoveConfigYaml(filepath.Join(t.TempDir(), "missing.yml"))
-	if !s.SourcesValid || len(s.DbtConfig.Sources) != 0 {
+	if !s.ServerCapabilitiesStatus.SourcesEnabled || len(s.DbtConfig.Sources) != 0 {
 		t.Fatal("unknown file changed source state")
 	}
 }
@@ -159,7 +173,11 @@ func TestReconcileProjectDeactivatesAndReactivates(t *testing.T) {
 
 func TestRepeatedProjectIndexingFailureNotifiesOnce(t *testing.T) {
 	root := t.TempDir()
-	writeTestFile(t, filepath.Join(root, "dbt_project.yml"), "name: example\nmodel-paths: [missing]\n")
+	writeTestFile(
+		t,
+		filepath.Join(root, "dbt_project.yml"),
+		"name: example\nmodel-paths: [missing]\n",
+	)
 	s := newTestState()
 	s.SetProjectRoot(root)
 	s.SetServerActive(true)
@@ -169,7 +187,10 @@ func TestRepeatedProjectIndexingFailureNotifiesOnce(t *testing.T) {
 
 	select {
 	case notif := <-s.NotifCh:
-		if notif.Message != "dbt-ls: project could not be indexed: lstat "+filepath.Join(root, "missing")+": no such file or directory" {
+		if notif.Message != "dbt-ls: project could not be indexed: lstat "+filepath.Join(
+			root,
+			"missing",
+		)+": no such file or directory" {
 			t.Fatalf("unexpected notification: %q", notif.Message)
 		}
 	default:

--- a/analysis/state.go
+++ b/analysis/state.go
@@ -25,36 +25,42 @@ func WorkspacePath(uri string) (string, error) {
 }
 
 type State struct {
-	Documents           map[string]*Document
-	DbtConfigMu         sync.Mutex
-	ProjectMu           sync.RWMutex
-	ProjectLifecycleMu  sync.Mutex
-	DbtConfig           DbtConfig
-	DbtRoots            []string
-	SourcesValid        bool
-	SourceFileErrors    map[string][]sourceFileError // keyed by file path; guarded by DbtConfigMu
-	NotifCh             chan lsp.ShowMessageParams
-	configFileHashes    map[string]string // file path → sha256 of last-processed content
-	configFileHashesMu  sync.Mutex
-	DbtSourcesByFile    map[string]DbtSources
-	SourceTableIndex    map[sourceTableKey]map[string][]sourceDecl
-	Root                []lsp.WorkspaceFolder // LSP-provided workspace folders (Name/URI)
-	RootPaths           []string              // parsed filesystem paths, index-aligned with Root
-	ServerActive        bool
-	ProjectRoot         string
-	ProjectConfigPath   string
-	ShutdownRequested   bool
-	DbtModelsMu         sync.Mutex
-	DbtModels           *trie.Trie[string]
-	DbtModelExtension   string
-	DbtConfigExtensions []string
-	ModelRoots          []string
-	ConfigRoot          string
-	Logger              *logger.Logger
-	Writer              io.Writer
-	ProjectWatcher      *DbtWatcher
-	watchedDirs         map[string]struct{}
-	watchedDirsMu       sync.Mutex
+	Documents                map[string]*Document
+	DbtConfigMu              sync.Mutex
+	ProjectMu                sync.RWMutex
+	ProjectLifecycleMu       sync.Mutex
+	DbtConfig                DbtConfig
+	DbtRoots                 []string
+	ServerActive             bool
+	ServerCapabilitiesStatus ServerCapabilitiesStatus
+	SourceFileErrors         map[string][]sourceFileError // keyed by file path; guarded by DbtConfigMu
+	NotifCh                  chan lsp.ShowMessageParams
+	configFileHashes         map[string]string // file path → sha256 of last-processed content
+	configFileHashesMu       sync.Mutex
+	DbtSourcesByFile         map[string]DbtSources
+	SourceTableIndex         map[sourceTableKey]map[string][]sourceDecl
+	Root                     []lsp.WorkspaceFolder // LSP-provided workspace folders (Name/URI)
+	RootPaths                []string              // parsed filesystem paths, index-aligned with Root
+	ProjectRoot              string
+	ProjectConfigPath        string
+	ShutdownRequested        bool
+	DbtModelsMu              sync.Mutex
+	DbtModels                *trie.Trie[string]
+	DbtModelExtension        string
+	DbtConfigExtensions      []string
+	ModelRoots               []string
+	ConfigRoot               string
+	Logger                   *logger.Logger
+	Writer                   io.Writer
+	ProjectWatcher           *DbtWatcher
+	watchedDirs              map[string]struct{}
+	watchedDirsMu            sync.Mutex
+}
+
+type ServerCapabilitiesStatus struct {
+	SourcesEnabled     bool
+	RefsEnabled        bool
+	DefinitionsEnabled bool
 }
 
 func (s *State) IsServerActive() bool {
@@ -65,6 +71,56 @@ func (s *State) IsServerActive() bool {
 
 func (s *State) SetServerActive(active bool) {
 	s.setServerActive(active)
+}
+
+func (s *State) setServerCapabilitiesStatus(status ServerCapabilitiesStatus) {
+	s.ProjectMu.Lock()
+	s.ServerCapabilitiesStatus = status
+	s.ProjectMu.Unlock()
+}
+
+func (s *State) setSourcesEnabled(enabled bool) {
+	s.ProjectMu.Lock()
+	s.ServerCapabilitiesStatus.SourcesEnabled = enabled
+	s.ProjectMu.Unlock()
+}
+
+func (s *State) sourcesEnabled() bool {
+	s.ProjectMu.RLock()
+	defer s.ProjectMu.RUnlock()
+	return s.ServerCapabilitiesStatus.SourcesEnabled
+}
+
+func (s *State) enableProjectCapabilities(sourcesEnabled bool) {
+	s.ProjectMu.Lock()
+	s.ServerCapabilitiesStatus = ServerCapabilitiesStatus{
+		SourcesEnabled:     sourcesEnabled,
+		RefsEnabled:        true,
+		DefinitionsEnabled: true,
+	}
+	s.ProjectMu.Unlock()
+}
+
+func (s *State) disableProjectCapabilities() {
+	s.setServerCapabilitiesStatus(ServerCapabilitiesStatus{})
+}
+
+func (s *State) IsSourceCompletionEnabled() bool {
+	s.ProjectMu.RLock()
+	defer s.ProjectMu.RUnlock()
+	return s.ServerActive && s.ServerCapabilitiesStatus.SourcesEnabled
+}
+
+func (s *State) IsRefCompletionEnabled() bool {
+	s.ProjectMu.RLock()
+	defer s.ProjectMu.RUnlock()
+	return s.ServerActive && s.ServerCapabilitiesStatus.RefsEnabled
+}
+
+func (s *State) IsDefinitionEnabled() bool {
+	s.ProjectMu.RLock()
+	defer s.ProjectMu.RUnlock()
+	return s.ServerActive && s.ServerCapabilitiesStatus.DefinitionsEnabled
 }
 
 func (s *State) SetProjectRoot(root string) {
@@ -109,14 +165,18 @@ func NewState(
 	models := trie.New[string]()
 
 	return &State{
-		Documents:           map[string]*Document{},
-		SourcesValid:        true,
+		Documents:    map[string]*Document{},
+		ServerActive: false,
+		ServerCapabilitiesStatus: ServerCapabilitiesStatus{
+			SourcesEnabled:     false,
+			RefsEnabled:        false,
+			DefinitionsEnabled: false,
+		},
 		SourceFileErrors:    map[string][]sourceFileError{},
 		NotifCh:             make(chan lsp.ShowMessageParams, 16),
 		configFileHashes:    map[string]string{},
 		DbtSourcesByFile:    map[string]DbtSources{},
 		SourceTableIndex:    map[sourceTableKey]map[string][]sourceDecl{},
-		ServerActive:        false,
 		ShutdownRequested:   false,
 		DbtModels:           models,
 		DbtModelExtension:   ".sql",
@@ -132,5 +192,6 @@ func NewState(
 
 func (s *State) Shutdown() {
 	s.setServerActive(false)
+	s.disableProjectCapabilities()
 	s.ShutdownRequested = true
 }

--- a/analysis/state_test.go
+++ b/analysis/state_test.go
@@ -1,0 +1,81 @@
+package analysis
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNewStateDisablesCapabilities(t *testing.T) {
+	s := newTestState()
+
+	if s.IsServerActive() {
+		t.Fatal("new state server is active")
+	}
+	if s.IsRefCompletionEnabled() {
+		t.Fatal("new state ref completion enabled")
+	}
+	if s.IsSourceCompletionEnabled() {
+		t.Fatal("new state source completion enabled")
+	}
+	if s.IsDefinitionEnabled() {
+		t.Fatal("new state definition enabled")
+	}
+}
+
+func TestActivateProjectEnablesCapabilities(t *testing.T) {
+	root := t.TempDir()
+	projectPath := filepath.Join(root, "dbt_project.yml")
+	writeTestFile(t, projectPath, "name: example\nmodel-paths: [models]\n")
+	writeTestFile(t, filepath.Join(root, "models", "orders.sql"), "select 1\n")
+
+	s := newTestState()
+	project, err := s.ParseDbtConfig(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ActivateProject(root, projectPath, project); err != nil {
+		t.Fatal(err)
+	}
+
+	if !s.IsServerActive() {
+		t.Fatal("server inactive after project activation")
+	}
+	if !s.IsRefCompletionEnabled() {
+		t.Fatal("ref completion disabled after project activation")
+	}
+	if !s.IsSourceCompletionEnabled() {
+		t.Fatal("source completion disabled after project activation")
+	}
+	if !s.IsDefinitionEnabled() {
+		t.Fatal("definition disabled after project activation")
+	}
+}
+
+func TestSourceConflictDisablesOnlySourceCompletion(t *testing.T) {
+	s := newTestState()
+	s.setServerActive(true)
+	s.enableProjectCapabilities(true)
+
+	dir := t.TempDir()
+	s.SetDbtSources(testSource("warehouse", "orders"), filepath.Join(dir, "a.yml"))
+	s.SetDbtSources(testSource("warehouse", "orders"), filepath.Join(dir, "b.yml"))
+
+	if s.IsSourceCompletionEnabled() {
+		t.Fatal("source completion enabled with source conflict")
+	}
+	if !s.IsRefCompletionEnabled() {
+		t.Fatal("source conflict disabled ref completion")
+	}
+	if !s.IsDefinitionEnabled() {
+		t.Fatal("source conflict disabled definition")
+	}
+}
+
+func TestDisableProjectCapabilitiesRequiresServerActive(t *testing.T) {
+	s := newTestState()
+	s.enableProjectCapabilities(true)
+
+	if s.IsRefCompletionEnabled() || s.IsSourceCompletionEnabled() || s.IsDefinitionEnabled() {
+		t.Fatal("capability getter ignored inactive server")
+	}
+}


### PR DESCRIPTION
Add new per-capability state, tracking the availability of different functionality.

Enable different capabilities with code gates based on aforementioned state.

Closes #10 